### PR TITLE
Upkeep: Remove invalid Next.js option

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,7 +27,6 @@ export default () => {
   writeJsonFileSync(DATA_PATH, getData())
 
   return {
-    cleanUrls: true,
     trailingSlash: false,
     eslint: {
       ignoreDuringBuilds: true


### PR DESCRIPTION
This PR removes the `cleanUrls` option.